### PR TITLE
Provide test defaults for Cognito config

### DIFF
--- a/src/config/awsConfig.ts
+++ b/src/config/awsConfig.ts
@@ -3,10 +3,10 @@
 const isTestEnv = process.env.NODE_ENV === 'test';
 
 const cognitoConfig = {
-    userPoolId: process.env.REACT_APP_USER_POOL_ID ?? (isTestEnv ? 'test-user-pool-id' : undefined),
-    clientId: process.env.REACT_APP_CLIENT_ID ?? (isTestEnv ? 'test-client-id' : undefined),
-    region: process.env.REACT_APP_REGION ?? (isTestEnv ? 'test-region' : undefined),
-    identityPoolId: process.env.REACT_APP_IDENTITY_POOL_ID ?? (isTestEnv ? 'test-identity-pool-id' : undefined),
+    userPoolId: process.env.REACT_APP_USER_POOL_ID ?? (isTestEnv ? 'us-east-1_TestPoolId' : undefined),
+    clientId: process.env.REACT_APP_CLIENT_ID ?? (isTestEnv ? '1234567890abcdef1234567890abcdef' : undefined),
+    region: process.env.REACT_APP_REGION ?? (isTestEnv ? 'us-east-1' : undefined),
+    identityPoolId: process.env.REACT_APP_IDENTITY_POOL_ID ?? (isTestEnv ? 'us-east-1:00000000-0000-0000-0000-000000000000' : undefined),
 };
 
 export default cognitoConfig;

--- a/src/config/awsConfig.ts
+++ b/src/config/awsConfig.ts
@@ -1,10 +1,12 @@
 // cognito-config.js
 
+const isTestEnv = process.env.NODE_ENV === 'test';
+
 const cognitoConfig = {
-    userPoolId: process.env.REACT_APP_USER_POOL_ID,
-    clientId: process.env.REACT_APP_CLIENT_ID,
-    region: process.env.REACT_APP_REGION,
-    identityPoolId: process.env.REACT_APP_IDENTITY_POOL_ID,
+    userPoolId: process.env.REACT_APP_USER_POOL_ID ?? (isTestEnv ? 'test-user-pool-id' : undefined),
+    clientId: process.env.REACT_APP_CLIENT_ID ?? (isTestEnv ? 'test-client-id' : undefined),
+    region: process.env.REACT_APP_REGION ?? (isTestEnv ? 'test-region' : undefined),
+    identityPoolId: process.env.REACT_APP_IDENTITY_POOL_ID ?? (isTestEnv ? 'test-identity-pool-id' : undefined),
 };
 
 export default cognitoConfig;


### PR DESCRIPTION
### Motivation
- Prevent test runs from failing when Cognito-related env vars are not set by providing safe fallbacks in test environment.

### Description
- Update `src/config/awsConfig.ts` to detect `NODE_ENV === 'test'` and use test-default strings when `REACT_APP_*` env vars are missing so `CognitoUserPool` initialization won't error.

### Testing
- No automated tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721b636ec88326a0eed85f796e71a5)